### PR TITLE
fsxc: de-prioritize netstandard2.0

### DIFF
--- a/fsxc/Program.fs
+++ b/fsxc/Program.fs
@@ -332,12 +332,13 @@ module Program =
 
                 let allowedFrameworkProfilesDirs =
                     [
-                        "netstandard2.0"
                         "net472"
                         "net471"
                         "net462"
                         "net461"
+                        "net452"
                         "net45"
+                        "netstandard2.0"
                     ]
 
                 let binDir =

--- a/test/testRefNugetLibNewFormat.fsx
+++ b/test/testRefNugetLibNewFormat.fsx
@@ -4,15 +4,10 @@ open System
 open System.IO
 open System.Linq
 
-#r "nuget: Microsoft.Build"
-open Microsoft.Build.Construction
+#r "nuget: TickSpec"
 
-let sol =
-    SolutionFile.Parse <| Path.Combine(__SOURCE_DIRECTORY__, "..", "fsx.sln")
+let someProcedure() =
+    ()
 
-for (proj: string) in
-    (sol
-        .ProjectsInOrder
-        .Select(fun p -> p.ProjectName)
-        .ToList()) do
-    Console.WriteLine proj
+let action: TickSpec.Action = TickSpec.Action someProcedure
+Console.WriteLine(action.GetType().FullName)

--- a/test/testRefNugetLibNewFormatWithVersion.fsx
+++ b/test/testRefNugetLibNewFormatWithVersion.fsx
@@ -4,15 +4,10 @@ open System
 open System.IO
 open System.Linq
 
-#r "nuget: Microsoft.Build, Version=16.11.0"
-open Microsoft.Build.Construction
+#r "nuget: TickSpec, Version=2.0.1"
 
-let sol =
-    SolutionFile.Parse <| Path.Combine(__SOURCE_DIRECTORY__, "..", "fsx.sln")
+let someProcedure() =
+    ()
 
-for (proj: string) in
-    (sol
-        .ProjectsInOrder
-        .Select(fun p -> p.ProjectName)
-        .ToList()) do
-    Console.WriteLine proj
+let action: TickSpec.Action = TickSpec.Action someProcedure
+Console.WriteLine(action.GetType().FullName)


### PR DESCRIPTION
The recently implemented `#r "NugetPkg"` feature doesn't really work for net4.x legacy when trying to consume netstandard2.0 binaries because it generates this error:

```
error FS0078: Unable to find the file 'netstandard.dll' in any of...
```

This PR doesn't fix the problem completely but mitigates it. At least it will make it work for nuget packages that also distribute net4.x binaries (and while we're at it, we add net452 which the TickSpec (the lib used in our nugetRef tests now) uses.