### PR TITLE
GitHubCI: usa vanilla VM for nuget publishing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,25 +10,42 @@ jobs:
     - sanity_check
 
     runs-on: ubuntu-22.04
+    container:
+      image: "ubuntu:22.04"
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Create version environment variable on normal push
+      - uses: actions/checkout@v1
+      - name: install sudo
+        run: apt update && apt install --yes sudo
+      - name: install dependencies
         run: |
-          source version.config
-          echo "version=$(dotnet fsi Tools/nugetPush.fsx --output-version $BaseVersion)" >> $GITHUB_ENV
-      - name: Create version environment variable when it's git tag
-        if: startsWith(github.ref, 'refs/tags/')
-        run: echo "version=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+            sudo apt install --yes git
+
+            sudo DEBIAN_FRONTEND=noninteractive apt install --yes dotnet6
+
+      # workaround for https://github.com/actions/runner/issues/2033
+      - name: ownership workaround
+        run: git config --global --add safe.directory '*'
+
+      - name: Compose full version on normal push
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          . ./version.config
+
+          # to disable welcome msg, see https://stackoverflow.com/a/70493818/544947
+          export DOTNET_NOLOGO=true
+
+          echo "\nFullVersion=`dotnet fsi Tools/nugetPush.fsx --output-version $BaseVersion`" >> ./version.config
+      - name: Get full version when it's git tag
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        run: echo "\nFullVersion=${GITHUB_REF#refs/*/}" >> ./version.config
       - name: Pack the fsxc NuGet package
         run: |
-          echo $version
-          dotnet pack fsxc/fsxc.fsproj -p:PackageVersion=$version
+          . ./version.config
+          dotnet pack fsxc/fsxc.fsproj -p:PackageVersion=$FullVersion
       - name: Pack the Fsdk NuGet package
         run: |
-          echo $version
-          dotnet pack Fsdk/Fsdk.fsproj -p:PackageVersion=$version
+          . ./version.config
+          dotnet pack Fsdk/Fsdk.fsproj -p:PackageVersion=$FullVersion
       - name: Publish fsxc on NuGet website
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
     container:
       image: "ubuntu:22.04"
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: install sudo
         run: apt update && apt install --yes sudo
       - name: install dependencies


### PR DESCRIPTION
This way we may prevent the nuget package to use the very latest of FSharp.Core (v7) instead of the one we are after (v6).