### PR TITLE
Fsdk,Tests,fsxc: set Fsharp.Core version to 4.7.0

### DIFF
--- a/Fsdk.Tests/Fsdk.Tests.fsproj
+++ b/Fsdk.Tests/Fsdk.Tests.fsproj
@@ -25,4 +25,8 @@
     <ProjectReference Include="..\Fsdk\Fsdk.fsproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="4.7.0" />
+  </ItemGroup>
+
 </Project>

--- a/Fsdk/Fsdk.fsproj
+++ b/Fsdk/Fsdk.fsproj
@@ -45,4 +45,8 @@
       PackagePath="ReadMe.md"
       />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="4.7.0" />
+  </ItemGroup>
 </Project>

--- a/fsxc/fsxc.fsproj
+++ b/fsxc/fsxc.fsproj
@@ -52,4 +52,8 @@
       Pack="true" 
       PackagePath="ReadMe.md"/>
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="4.7.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Set Fsharp.Core version to 4.7.0 so that Fsdk package doesn't cause version conflicts in geewallet and NOnion.