### PR TITLE
Fsxc: support short version of nuget refs

### DIFF
--- a/fsxc/Fsxc.fs
+++ b/fsxc/Fsxc.fs
@@ -196,25 +196,40 @@ module Program =
                 let libToRef =
                     line.Substring(
                         REFNUGET_PREPROCESSOR.Length,
+
+                        // to remove the last double-quote character
                         line.Length - REFNUGET_PREPROCESSOR.Length - 1
                     )
 
-                let versionPattern = ", Version="
 
                 let libName, maybeVersion =
-                    if libToRef.Contains versionPattern then
-                        let versionPatternIndex =
-                            libToRef.IndexOf versionPattern
+                    if libToRef.Contains "," then
+                        let versionPattern = ", Version="
 
-                        let theNameOnly =
-                            libToRef.Substring(0, versionPatternIndex)
+                        if libToRef.Contains versionPattern then
+                            let versionPatternIndex =
+                                libToRef.IndexOf versionPattern
 
-                        theNameOnly,
-                        Some(
-                            libToRef.Substring(
-                                versionPatternIndex + versionPattern.Length
-                            )
-                        )
+                            let theNameOnly =
+                                libToRef.Substring(0, versionPatternIndex)
+
+                            let versionNumber =
+                                libToRef.Substring(
+                                    versionPatternIndex + versionPattern.Length
+                                )
+
+                            theNameOnly, (Some versionNumber)
+                        else
+                            let commaIndex = libToRef.IndexOf ","
+                            let theNameOnly = libToRef.Substring(0, commaIndex)
+
+                            let versionNumber =
+                                libToRef
+                                    .Substring(commaIndex + ",".Length)
+                                    .Trim()
+
+                            theNameOnly, (Some versionNumber)
+
                     else
                         libToRef, None
 

--- a/scripts/runTests.fsx
+++ b/scripts/runTests.fsx
@@ -282,6 +282,19 @@ Process.Execute(
 )
 |> UnwrapDefault
 
+let refNugetLibTestNewFormatWithShortVersion =
+    Path.Combine(
+        TestDir.FullName,
+        "testRefNugetLibNewFormatWithShortVersion.fsx"
+    )
+    |> FileInfo
+
+Process.Execute(
+    CreateCommand(refNugetLibTestNewFormatWithShortVersion, String.Empty),
+    Echo.All
+)
+|> UnwrapDefault
+
 
 let cmdLineArgsTest =
     Path.Combine(TestDir.FullName, "testFsiCommandLineArgs.fsx") |> FileInfo

--- a/test/testRefNugetLibNewFormatWithShortVersion.fsx
+++ b/test/testRefNugetLibNewFormatWithShortVersion.fsx
@@ -1,0 +1,13 @@
+#!/usr/bin/env fsx
+
+open System
+open System.IO
+open System.Linq
+
+#r "nuget: TickSpec, 2.0.1"
+
+let someProcedure() =
+    ()
+
+let action: TickSpec.Action = TickSpec.Action someProcedure
+Console.WriteLine(action.GetType().FullName)


### PR DESCRIPTION
It turns out that `#r "nuget: Foo, Version=X.Y.Z"` is not the only valid syntax, a shorter version exists without the `Version=` part.