### PR TITLE
Fsdk: embedded resource func fix

### DIFF
--- a/Fsdk/Misc.fs
+++ b/Fsdk/Misc.fs
@@ -881,5 +881,5 @@ module Misc =
                 allResourceNames
 
     let ExtractEmbeddedResourceFileContents(resourceName: string) =
-        let assembly = Assembly.GetExecutingAssembly()
+        let assembly = Assembly.GetCallingAssembly()
         ExtractEmbeddedResourceFileContentsFromAssembly resourceName assembly


### PR DESCRIPTION
Fix in ExtractEmbeddedResourceFileContents
function: use Assembly.GetCallingAssembly() for current assembly as GetExecutingAssembly() will return Fsdk assembly - that is not what the client code expects.