### PR TITLE
GithubCI: switch to MacOS 13

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -91,7 +91,7 @@ jobs:
         git diff --exit-code
 
   macOS--dotnet6-and-mono:
-    runs-on: macOS-12
+    runs-on: macOS-13
     steps:
     - uses: actions/checkout@v1
     - name: Setup .NET SDK 6.0.x
@@ -120,7 +120,7 @@ jobs:
       run: ./compileFSharpScripts.fsx
 
   macOS--mono:
-    runs-on: macOS-12
+    runs-on: macOS-13
     steps:
     - uses: actions/checkout@v1
     - name: HACK to emulate dotnet uninstall


### PR DESCRIPTION
Change MacOS version used in CI to 13, as version 12 got
deprecated [1] and causes the jobs to be cancelled.

[1] https://github.com/actions/runner-images/issues/10721